### PR TITLE
Fix incompatibility with `gulp.dest`

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,12 +40,9 @@ function plugin(opts) {
 
   function endStream() {
     if (firstFile) {
-      var joinedPath = path.join(firstFile.base, opts.output);
-
       var newFile = new File({
         cwd: firstFile.cwd,
-        base: firstFile.base,
-        path: joinedPath,
+        path: opts.output,
         contents: new Buffer(wrapContents(contents.join('\n')))
       });
 


### PR DESCRIPTION
Unless I'm missing something, this seems to make things work when using `gulp.dest`. It was generating really odd paths otherwise.
