### PR TITLE
Fix: Allow gulp tasks to exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ function plugin(opts) {
 
   var firstFile = null;
   var contents = null;
+  var nunjucksPath = opts.templatePath || path.join(__dirname, 'templates');
+  var nunjucksOpts = {
+    watch: false,
+  };
 
-  nunjucks.configure(opts.templatePath || path.join(__dirname, 'templates'));
+  nunjucks.configure(nunjucksPath, nunjucksOpts);
 
   function process(file) {
     var parseOptions = {};


### PR DESCRIPTION
Fixes #2 

Next step could be, to passing the nunjucks options into the plugin function. What do you think about this?