### PR TITLE
updated nunjucks version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-util": "^2.2.20",
     "through": "^2.3.4",
     "dss": "^1.0.4",
-    "nunjucks": "^1.0.5"
+    "nunjucks": "^3.0.1"
   },
   "devDependencies": {
     "mocha": "^1.20.1",


### PR DESCRIPTION
When using node version 6 or higher my gulp-dss fails with the following error: 

```
14:09:33] Starting 'dss'...
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.

==== JS stack trace =========================================

Security context: 0x20d1f9acf781 <JS Object>#0#
    1: .node [module.js:597] [pc=0x1ca9a6fda064] (this=0xfcab4f8c041 <an Object with deprecated map 0x35dea331ba11>#1#,module=0x62e85e1f8e9 <a Module with map 0x35dea331cf09>#2#,filename=0x62e85e1dbf1 <String[132]: /private/var/www/projects/example-project/wp-content/themes/example-theme/node_modules/nunjucks/node_modules/fsevents/build/Release/fse.node>)

```

Updating nunjucks to it's lastest version (currently 3.0.1) solves this issue.